### PR TITLE
Display closeable message to zoom for more detail

### DIFF
--- a/app/src/constants.ts
+++ b/app/src/constants.ts
@@ -45,6 +45,8 @@ export const PUMAS_SOURCE_LAYER = "pumas";
 
 export const PUMAS_MIN_ZOOM_LEVEL = 7;
 
+export const ZOOM_INFO_WAS_CLOSED_ID = "zoom-info-was-closed";
+
 // Spanish
 export const DEFAULT_LANGUAGE_CODE = "1200";
 

--- a/app/src/main.ts
+++ b/app/src/main.ts
@@ -9,6 +9,7 @@ import {
   STATES_PUMAS_SOURCE_ID,
   STATES_SOURCE_LAYER,
   TOP_N,
+  ZOOM_INFO_WAS_CLOSED_ID,
 } from "./constants";
 import {
   Area,
@@ -196,6 +197,14 @@ function refreshView(filters: Filters) {
 // Initialize labels for mobile
 refreshMobile(appState.filters);
 
+// Zoom info element
+const zoomInfoElem = querySelectorThrows("#zoom-info");
+const hideZoomInfoElem = querySelectorThrows("#hide-zoom-info");
+hideZoomInfoElem.addEventListener("click", () => {
+  zoomInfoElem.style.display = "none";
+  localStorage.setItem(ZOOM_INFO_WAS_CLOSED_ID, "true");
+});
+
 // Build legend
 const legendElem = querySelectorThrows("#legend");
 function refreshLegend(year: Year | YearRange) {
@@ -364,6 +373,11 @@ map.on("load", function () {
     ) {
       tooltip.remove();
     }
+    zoomInfoElem.style.display =
+      zoom >= PUMAS_MIN_ZOOM_LEVEL ||
+      localStorage.getItem(ZOOM_INFO_WAS_CLOSED_ID) !== null
+        ? "none"
+        : "block";
     prevZoom = zoom;
   });
 

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -271,6 +271,12 @@
 
       <div class="map-container">
         <div id="map" class="map"></div>
+        <div id="zoom-info" class="zoom-info">
+          <div class="zoom__content">
+            <h2 class="zoom__title">Zoom for More Detail</h2>
+            <span id="hide-zoom-info" class="zoom__close">&#x2715;</span>
+          </div>
+        </div>
         <div id="legend" class="legend"></div>
         <div class="legend__toggle-container">
           <button type="button" id="show_legend" class="button">

--- a/app/static/main.css
+++ b/app/static/main.css
@@ -304,6 +304,46 @@ a:focus {
 }
 
 /**
+ * ZOOM INFO
+ */
+.zoom-info {
+  background-color: lightyellow;
+  position: absolute;
+  top: 10px;
+  margin-left: 50%;
+  transform: translateX(-50%);
+  padding: 5px;
+  border: 1px solid var(--light-border-color);
+  border-radius: var(--border-radius);
+  box-shadow: 0px 2px 28px -2px rgba(0,0,0,0.4);
+  z-index: 3;
+  display: none;
+}
+
+.zoom__content {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.zoom__title {
+  padding-left: 5px;
+  min-width: 150px;
+  font-size: var(--font-size-normal);
+  font-weight: var(--font-weight-normal);
+}
+
+.zoom__close {
+  font-size: var(--font-size-large);
+  margin-left: 5px;
+  padding: 0.5rem;
+  border-radius: 1rem;
+  line-height: 0.75rem;
+  cursor: pointer;
+}
+
+
+/**
  * MAP LEGEND
  */
 .legend {


### PR DESCRIPTION
Looks like this when open on desktop and mobile:

![Screenshot from 2025-01-15 23-06-48](https://github.com/user-attachments/assets/9090e276-8960-4c5b-8959-efa20c0dff35)

![Screenshot from 2025-01-15 23-08-08](https://github.com/user-attachments/assets/addfc536-ac57-4b62-aa33-95e495dc3dfe)

Once you click/tap the 'X' it's hidden forever on that device.